### PR TITLE
Remove redundant func call in CallbackSerializer

### DIFF
--- a/src/CallbackSerializer.php
+++ b/src/CallbackSerializer.php
@@ -24,11 +24,11 @@ final class CallbackSerializer implements SerializerInterface
 
     public function serialize($value): string
     {
-        return \call_user_func($this->serializeCallback, $value);
+        return ($this->serializeCallback)($value);
     }
 
     public function unserialize(string $value)
     {
-        return \call_user_func($this->unserializeCallback, $value);
+        return ($this->unserializeCallback)($value);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ✔️/❌
| Breaks BC?    | ✔️/❌
| Fixed issues  | -

Replaces redundant use of the `call_user_func()` function with a simple callback.
